### PR TITLE
Stroke, and Stroke Width attributes also used when drawing text.

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,16 +122,18 @@ Draw an elliptical arc centered at (x, y), with width and height at (w, h).  Sta
 ### Text and Images
 
 	void Text(VGfloat x, VGfloat y, char* s, Fontinfo f, int pointsize)
-Draw a the text srtring (s) at location (x,y), using pointsize.
+Draw the text string (s) at location (x,y), using pointsize.
 
 	void TextMid(VGfloat x, VGfloat y, char* s, Fontinfo f, int pointsize)
-Draw a the text srtring (s) at centered at location (x,y), using pointsize.
+Draw the text string (s) centered at location (x,y), using pointsize.
 
 	void TextEnd(VGfloat x, VGfloat y, char* s, Fontinfo f, int pointsize)
-Draw a the text srtring (s) at with its lend aligned to location (x,y), using pointsize
+Draw the text string (s) with its left end aligned to location (x,y), using pointsize.
 
 	VGfloat TextWidth(char *s, Fontinfo f, int pointsize)
 Return the width of text
+
+Outlined text can be drawn by setting the appropriate Fill, Stroke, and Stroke Width [attributes](#attributes).
 
 	void Image(VGfloat x, VGfloat y, int w, int h, char * filename)
 place a JPEG image with dimensions (w,h) at (x,y).

--- a/libshapes.c
+++ b/libshapes.c
@@ -386,8 +386,10 @@ void FillRadialGradient(VGfloat cx, VGfloat cy, VGfloat fx, VGfloat fy, VGfloat 
 // derived from http://web.archive.org/web/20070808195131/http://developer.hybrid.fi/font2openvg/renderFont.cpp.txt
 void Text(VGfloat x, VGfloat y, char *s, Fontinfo f, int pointsize) {
 	VGfloat size = (VGfloat) pointsize, xx = x, mm[9];
+	VGfloat strk = vgGetf(VG_STROKE_LINE_WIDTH);
 	int i;
-
+	
+	vgSetf(VG_STROKE_LINE_WIDTH, strk / size); // scaled size
 	vgGetMatrix(mm);
 	for (i = 0; i < (int)strlen(s); i++) {
 		unsigned int character = (unsigned int)s[i];
@@ -402,10 +404,11 @@ void Text(VGfloat x, VGfloat y, char *s, Fontinfo f, int pointsize) {
 		};
 		vgLoadMatrix(mm);
 		vgMultMatrix(mat);
-		vgDrawPath(f.Glyphs[glyph], VG_FILL_PATH);
+		vgDrawPath(f.Glyphs[glyph], VG_FILL_PATH | VG_STROKE_PATH);
 		xx += size * f.GlyphAdvances[glyph] / 65536.0f;
 	}
-	vgLoadMatrix(mm);
+	vgLoadMatrix(mm);	
+	vgSetf(VG_STROKE_LINE_WIDTH, strk); // return to unscaled stroke size
 }
 
 // TextWidth returns the width of a text string at the specified font and size.


### PR DESCRIPTION
Text is now drawn with VG_FILL_PATH and VG_STROKE_PATH.

This allows text to be outlined with any stroke width and color.
