### PR TITLE
Fontinfo Multiple Definitions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,13 @@ INCLUDEFLAGS=-I/opt/vc/include -I/opt/vc/include/interface/vmcs_host/linux -I/op
 LIBFLAGS=-L/opt/vc/lib -lGLESv2 -lEGL -ljpeg
 FONTLIB=/usr/share/fonts/truetype/ttf-dejavu
 FONTFILES=DejaVuSans.inc  DejaVuSansMono.inc DejaVuSerif.inc
-all:	libshapes.o oglinit.o
+all:	libshapes.o fontinfo.o oglinit.o
 
 libshapes.o:	libshapes.c shapes.h fontinfo.h fonts
 	gcc -O2 -Wall $(INCLUDEFLAGS) -c libshapes.c
+
+fontinfo.o:	fontinfo.c fontinfo.h shapes.h fonts
+	gcc -O2 -Wall $(INCLUDEFLAGS) -c fontinfo.c
 
 gopenvg:	openvg.go
 	go install .
@@ -28,13 +31,13 @@ DejaVuSansMono.inc: font2openvg $(FONTLIB)/DejaVuSansMono.ttf
 	./font2openvg $(FONTLIB)/DejaVuSansMono.ttf DejaVuSansMono.inc DejaVuSansMono
 
 indent:
-	indent -linux -c 60 -brf -l 132  libshapes.c oglinit.c shapes.h fontinfo.h
+	indent -linux -c 60 -brf -l 132  libshapes.c oglinit.c fontinfo.c shapes.h fontinfo.h
 
 clean:
 	rm -f *.o *.inc *.so font2openvg *.c~ *.h~
 
-library: oglinit.o libshapes.o indent
-	gcc $(LIBFLAGS) -shared -o libshapes.so oglinit.o libshapes.o
+library: oglinit.o libshapes.o fontinfo.o indent
+	gcc $(LIBFLAGS) -shared -o libshapes.so oglinit.o libshapes.o fontinfo.o
 
 install:
 	install -m 755 -p font2openvg /usr/bin/

--- a/README.md
+++ b/README.md
@@ -122,16 +122,18 @@ Draw an elliptical arc centered at (x, y), with width and height at (w, h).  Sta
 ### Text and Images
 
 	void Text(VGfloat x, VGfloat y, char* s, Fontinfo f, int pointsize)
-Draw a the text srtring (s) at location (x,y), using pointsize.
+Draw the text string (s) at location (x,y), using pointsize.
 
 	void TextMid(VGfloat x, VGfloat y, char* s, Fontinfo f, int pointsize)
-Draw a the text srtring (s) at centered at location (x,y), using pointsize.
+Draw the text string (s) centered at location (x,y), using pointsize.
 
 	void TextEnd(VGfloat x, VGfloat y, char* s, Fontinfo f, int pointsize)
-Draw a the text srtring (s) at with its lend aligned to location (x,y), using pointsize
+Draw the text string (s) with its left end aligned to location (x,y), using pointsize.
 
 	VGfloat TextWidth(char *s, Fontinfo f, int pointsize)
 Return the width of text
+
+Outlined text can be drawn by setting the appropriate Fill, Stroke, and Stroke Width [attributes](#attributes).
 
 	void Image(VGfloat x, VGfloat y, int w, int h, char * filename)
 place a JPEG image with dimensions (w,h) at (x,y).

--- a/client/Makefile
+++ b/client/Makefile
@@ -6,20 +6,23 @@ all: shapedemo hellovg mouse-hellovg
 libshapes.o:
 	cd .. ; make libshapes.o
 
+fontinfo.o:
+	cd .. ; make fontinfo.o
+
 oglinit.o:
 	cd .. ; make oglinit.o
 
-shapedemo:	shapedemo.c libshapes.o oglinit.o
-	gcc -Wall $(INCLUDEFLAGS) $(LIBFLAGS) -o shapedemo shapedemo.c ../libshapes.o ../oglinit.o
+shapedemo:	shapedemo.c libshapes.o fontinfo.o oglinit.o
+	gcc -Wall $(INCLUDEFLAGS) $(LIBFLAGS) -o shapedemo shapedemo.c ../libshapes.o ../fontinfo.o ../oglinit.o
 
 test:	shapedemo
 	./shapedemo demo 5
 
-hellovg:	hellovg.c ../libshapes.o ../oglinit.o
-	gcc -Wall $(INCLUDEFLAGS) $(LIBFLAGS) -o  hellovg hellovg.c ../libshapes.o ../oglinit.o
+hellovg:	hellovg.c ../libshapes.o ../fontinfo.o ../oglinit.o
+	gcc -Wall $(INCLUDEFLAGS) $(LIBFLAGS) -o  hellovg hellovg.c ../libshapes.o ../fontinfo.o ../oglinit.o
 
-mouse-hellovg:	mouse-hellovg.c ../libshapes.o ../oglinit.o
-	gcc -Wall $(INCLUDEFLAGS) $(LIBFLAGS) -o  mouse-hellovg mouse-hellovg.c ../libshapes.o ../oglinit.o
+mouse-hellovg:	mouse-hellovg.c ../libshapes.o ../fontinfo.o ../oglinit.o
+	gcc -Wall $(INCLUDEFLAGS) $(LIBFLAGS) -o  mouse-hellovg mouse-hellovg.c ../libshapes.o ../fontinfo.o ../oglinit.o
 
 indent:
 	indent -linux -c 60 -brf -l 132 shapedemo.c hellovg.c mouse-hellovg.c

--- a/fontinfo.c
+++ b/fontinfo.c
@@ -1,0 +1,3 @@
+#include "fontinfo.h"
+
+Fontinfo SansTypeface, SerifTypeface, MonoTypeface;

--- a/fontinfo.h
+++ b/fontinfo.h
@@ -10,5 +10,8 @@ typedef struct {
 	VGPath Glyphs[256];
 } Fontinfo;
 
-Fontinfo SansTypeface, SerifTypeface, MonoTypeface;
+extern Fontinfo SansTypeface;
+extern Fontinfo SerifTypeface;
+extern Fontinfo MonoTypeface;
+
 #endif				// OPENVG_FONTINFO_H

--- a/fontinfo.h
+++ b/fontinfo.h
@@ -1,5 +1,8 @@
 #ifndef OPENVG_FONTINFO_H
 #define OPENVG_FONTINFO_H
+
+#include <VG/openvg.h>
+
 typedef struct {
 	const short *CharacterMap;
 	const int *GlyphAdvances;

--- a/libshapes.c
+++ b/libshapes.c
@@ -386,8 +386,10 @@ void FillRadialGradient(VGfloat cx, VGfloat cy, VGfloat fx, VGfloat fy, VGfloat 
 // derived from http://web.archive.org/web/20070808195131/http://developer.hybrid.fi/font2openvg/renderFont.cpp.txt
 void Text(VGfloat x, VGfloat y, char *s, Fontinfo f, int pointsize) {
 	VGfloat size = (VGfloat) pointsize, xx = x, mm[9];
+	VGfloat strk = vgGetf(VG_STROKE_LINE_WIDTH);
 	int i;
-
+	
+	vgSetf(VG_STROKE_LINE_WIDTH, strk / size); // scaled size
 	vgGetMatrix(mm);
 	for (i = 0; i < (int)strlen(s); i++) {
 		unsigned int character = (unsigned int)s[i];
@@ -402,10 +404,11 @@ void Text(VGfloat x, VGfloat y, char *s, Fontinfo f, int pointsize) {
 		};
 		vgLoadMatrix(mm);
 		vgMultMatrix(mat);
-		vgDrawPath(f.Glyphs[glyph], VG_FILL_PATH);
+		vgDrawPath(f.Glyphs[glyph], VG_FILL_PATH | VG_STROKE_PATH);
 		xx += size * f.GlyphAdvances[glyph] / 65536.0f;
 	}
-	vgLoadMatrix(mm);
+	vgLoadMatrix(mm);	
+	vgSetf(VG_STROKE_LINE_WIDTH, strk); // return to unscaled stroke size
 }
 
 // TextWidth returns the width of a text string at the specified font and size.


### PR DESCRIPTION
Foninfo.h can't be included more than once in a project because of the instantiation of SansTypeface, SerifTypeface, and MonoTypeface within the fontinfo header file.

This puts that line of code into a separate file which can be compiled and linked in as usual.