### PR TITLE
Fix multiple linkage and build issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+font2openvg
+*~
+*.o
+*.so

--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,17 @@ INCLUDEFLAGS=-I/opt/vc/include -I/opt/vc/include/interface/vmcs_host/linux -I/op
 LIBFLAGS=-L/opt/vc/lib -lGLESv2 -lEGL -ljpeg
 FONTLIB=/usr/share/fonts/truetype/ttf-dejavu
 FONTFILES=DejaVuSans.inc  DejaVuSansMono.inc DejaVuSerif.inc
-all:	libshapes.o oglinit.o
+
+all:	font2openvg fonts library
 
 libshapes.o:	libshapes.c shapes.h fontinfo.h fonts
-	gcc -O2 -Wall $(INCLUDEFLAGS) -c libshapes.c
+	gcc -g -O2 -Wall $(INCLUDEFLAGS) -c libshapes.c
 
 gopenvg:	openvg.go
 	go install .
 
 oglinit.o:	oglinit.c
-	gcc -O2 -Wall $(INCLUDEFLAGS) -c oglinit.c
+	gcc -g -O2 -Wall $(INCLUDEFLAGS) -c oglinit.c
 
 font2openvg:	fontutil/font2openvg.cpp
 	g++ -I/usr/include/freetype2 fontutil/font2openvg.cpp -o font2openvg -lfreetype
@@ -34,12 +35,12 @@ clean:
 	rm -f *.o *.inc *.so font2openvg *.c~ *.h~
 
 library: oglinit.o libshapes.o indent
-	gcc $(LIBFLAGS) -shared -o libshapes.so oglinit.o libshapes.o
+	gcc -g $(LIBFLAGS) -shared -o libshapes.so oglinit.o libshapes.o
 
 install:
 	install -m 755 -p font2openvg /usr/bin/
 	install -m 755 -p libshapes.so /usr/lib/libshapes.so.1.0.0
-	strip --strip-unneeded /usr/lib/libshapes.so.1.0.0
+	#strip --strip-unneeded /usr/lib/libshapes.so.1.0.0
 	ln -f -s /usr/lib/libshapes.so.1.0.0 /usr/lib/libshapes.so
 	ln -f -s /usr/lib/libshapes.so.1.0.0 /usr/lib/libshapes.so.1
 	ln -f -s /usr/lib/libshapes.so.1.0.0 /usr/lib/libshapes.so.1.0

--- a/fontinfo.h
+++ b/fontinfo.h
@@ -1,11 +1,20 @@
 #ifndef OPENVG_FONTINFO_H
 #define OPENVG_FONTINFO_H
-typedef struct {
-	const short *CharacterMap;
-	const int *GlyphAdvances;
-	int Count;
-	VGPath Glyphs[256];
-} Fontinfo;
 
-Fontinfo SansTypeface, SerifTypeface, MonoTypeface;
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+	typedef struct {
+		const short *CharacterMap;
+		const int *GlyphAdvances;
+		int Count;
+		VGPath Glyphs[256];
+	} Fontinfo;
+
+	extern Fontinfo SansTypeface, SerifTypeface, MonoTypeface;
+
+#if defined(__cplusplus)
+}
+#endif
 #endif				// OPENVG_FONTINFO_H

--- a/libshapes.c
+++ b/libshapes.c
@@ -212,6 +212,8 @@ void dumpscreen(int w, int h, FILE * fp) {
 	free(ScreenBuffer);
 }
 
+Fontinfo SansTypeface, SerifTypeface, MonoTypeface;
+
 // init sets the system to its initial state
 void init(int *w, int *h) {
 	bcm_host_init();

--- a/shapes.h
+++ b/shapes.h
@@ -1,45 +1,51 @@
 #include <VG/openvg.h>
 #include <VG/vgu.h>
 #include "fontinfo.h"
-extern void Translate(VGfloat, VGfloat);
-extern void Rotate(VGfloat);
-extern void Shear(VGfloat, VGfloat);
-extern void Scale(VGfloat, VGfloat);
-extern void Text(VGfloat, VGfloat, char *, Fontinfo, int);
-extern void TextMid(VGfloat, VGfloat, char *, Fontinfo, int);
-extern void TextEnd(VGfloat, VGfloat, char *, Fontinfo, int);
-extern VGfloat TextWidth(char *, Fontinfo, int);
-extern void Cbezier(VGfloat, VGfloat, VGfloat, VGfloat, VGfloat, VGfloat, VGfloat, VGfloat);
-extern void Qbezier(VGfloat, VGfloat, VGfloat, VGfloat, VGfloat, VGfloat);
-extern void Polygon(VGfloat *, VGfloat *, VGint);
-extern void Polyline(VGfloat *, VGfloat *, VGint);
-extern void Rect(VGfloat, VGfloat, VGfloat, VGfloat);
-extern void Line(VGfloat, VGfloat, VGfloat, VGfloat);
-extern void Roundrect(VGfloat, VGfloat, VGfloat, VGfloat, VGfloat, VGfloat);
-extern void Ellipse(VGfloat, VGfloat, VGfloat, VGfloat);
-extern void Circle(VGfloat, VGfloat, VGfloat);
-extern void Arc(VGfloat, VGfloat, VGfloat, VGfloat, VGfloat, VGfloat);
-extern void Image(VGfloat, VGfloat, int, int, char *);
-extern void Start(int, int);
-extern void End();
-extern void SaveEnd(char *);
-extern void Background(unsigned int, unsigned int, unsigned int);
-extern void BackgroundRGB(unsigned int, unsigned int, unsigned int, VGfloat);
-extern void init(int *, int *);
-extern void finish();
-extern void setfill(VGfloat[4]);
-extern void setstroke(VGfloat[4]);
-extern void StrokeWidth(VGfloat);
-extern void Stroke(unsigned int, unsigned int, unsigned int, VGfloat);
-extern void Fill(unsigned int, unsigned int, unsigned int, VGfloat);
-extern void RGBA(unsigned int, unsigned int, unsigned int, VGfloat, VGfloat[4]);
-extern void RGB(unsigned int, unsigned int, unsigned int, VGfloat[4]);
-extern void FillLinearGradient(VGfloat, VGfloat, VGfloat, VGfloat, VGfloat *, int);
-extern void FillRadialGradient(VGfloat, VGfloat, VGfloat, VGfloat, VGfloat, VGfloat *, int);
-extern Fontinfo loadfont(const int *, const int *, const unsigned char *, const int *, const int *, const int *, const short *,
-			 int);
-extern void unloadfont(VGPath *, int);
-extern void makeimage(VGfloat, VGfloat, int, int, VGubyte *);
-extern void saveterm();
-extern void restoreterm();
-extern void rawterm();
+#if defined(__cplusplus)
+extern "C" {
+#endif
+	extern void Translate(VGfloat, VGfloat);
+	extern void Rotate(VGfloat);
+	extern void Shear(VGfloat, VGfloat);
+	extern void Scale(VGfloat, VGfloat);
+	extern void Text(VGfloat, VGfloat, char *, Fontinfo, int);
+	extern void TextMid(VGfloat, VGfloat, char *, Fontinfo, int);
+	extern void TextEnd(VGfloat, VGfloat, char *, Fontinfo, int);
+	extern VGfloat TextWidth(char *, Fontinfo, int);
+	extern void Cbezier(VGfloat, VGfloat, VGfloat, VGfloat, VGfloat, VGfloat, VGfloat, VGfloat);
+	extern void Qbezier(VGfloat, VGfloat, VGfloat, VGfloat, VGfloat, VGfloat);
+	extern void Polygon(VGfloat *, VGfloat *, VGint);
+	extern void Polyline(VGfloat *, VGfloat *, VGint);
+	extern void Rect(VGfloat, VGfloat, VGfloat, VGfloat);
+	extern void Line(VGfloat, VGfloat, VGfloat, VGfloat);
+	extern void Roundrect(VGfloat, VGfloat, VGfloat, VGfloat, VGfloat, VGfloat);
+	extern void Ellipse(VGfloat, VGfloat, VGfloat, VGfloat);
+	extern void Circle(VGfloat, VGfloat, VGfloat);
+	extern void Arc(VGfloat, VGfloat, VGfloat, VGfloat, VGfloat, VGfloat);
+	extern void Image(VGfloat, VGfloat, int, int, char *);
+	extern void Start(int, int);
+	extern void End();
+	extern void SaveEnd(char *);
+	extern void Background(unsigned int, unsigned int, unsigned int);
+	extern void BackgroundRGB(unsigned int, unsigned int, unsigned int, VGfloat);
+	extern void init(int *, int *);
+	extern void finish();
+	extern void setfill(VGfloat[4]);
+	extern void setstroke(VGfloat[4]);
+	extern void StrokeWidth(VGfloat);
+	extern void Stroke(unsigned int, unsigned int, unsigned int, VGfloat);
+	extern void Fill(unsigned int, unsigned int, unsigned int, VGfloat);
+	extern void RGBA(unsigned int, unsigned int, unsigned int, VGfloat, VGfloat[4]);
+	extern void RGB(unsigned int, unsigned int, unsigned int, VGfloat[4]);
+	extern void FillLinearGradient(VGfloat, VGfloat, VGfloat, VGfloat, VGfloat *, int);
+	extern void FillRadialGradient(VGfloat, VGfloat, VGfloat, VGfloat, VGfloat, VGfloat *, int);
+	extern Fontinfo loadfont(const int *, const int *, const unsigned char *, const int *, const int *, const int *,
+				 const short *, int);
+	extern void unloadfont(VGPath *, int);
+	extern void makeimage(VGfloat, VGfloat, int, int, VGubyte *);
+	extern void saveterm();
+	extern void restoreterm();
+	extern void rawterm();
+#if defined(__cplusplus)
+}
+#endif


### PR DESCRIPTION
Fix fontinfo.h multiple symbol definition problem. (NEVER define symbols with storage in a header!)
Fix C++ name mangling problem (still C compatible.)
Fix Makefile to be more helpful to initial users and match the README build instructions.
Add .gitignore.
