### PR TITLE
Window-like mode and outlined (non-filled) shapes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ Here is the graphics equivalent of "hello, world"
 		initWindowSize(20, 20, 600, 360);
 		init(&width, &height);					// Graphics initialization
 	
-		// Remove Start as it sets up things we change anyway
-		//Start(width, height);					// Start the picture
+		Start(width, height);					// Start the picture
 		Background(0, 0, 0);					// Black background
 		Fill(44, 77, 232, 1);					// Big blue marble
 		Circle(width / 2, 0, width);			// The "world"

--- a/README.md
+++ b/README.md
@@ -31,9 +31,7 @@ Here is the graphics equivalent of "hello, world"
 		//Start(width, height);					// Start the picture
 		Background(0, 0, 0);					// Black background
 		Fill(44, 77, 232, 1);					// Big blue marble
-		Circle(width / 2, 0, width / 3);			// The "world" (made smaller)
-		Stroke(25, 125, 232, 1)				// Halo Colour
-		CircleOutline(width / 2, 0, (width / 3) + 5)	// Halo
+		Circle(width / 2, 0, width);			// The "world"
 
 		Fill(255, 255, 255, 1);					// White text
 		TextMid(width / 2, height / 2, "hello, world", SerifTypeface, width / 10);	// Greetings 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Here is the graphics equivalent of "hello, world"
 		init(&width, &height);					// Graphics initialization
 	
 		// Remove Start as it sets up things we change anyway
-		Start(width, height);					// Start the picture
+		//Start(width, height);					// Start the picture
 		Background(0, 0, 0);					// Black background
 		Fill(44, 77, 232, 1);					// Big blue marble
 		Circle(width / 2, 0, width / 3);			// The "world" (made smaller)

--- a/README_orig.md
+++ b/README_orig.md
@@ -1,6 +1,4 @@
 #Testbed for exploring OpenVG on the Raspberry Pi.
-Forked version of ajstarks' libshapes. Windowed mode and outline shapes
-functions by paeryn (paeryn@gmail.com).
 
 <a href="http://www.flickr.com/photos/ajstarks/7811750326/" title="rotext by ajstarks, on Flickr"><img src="http://farm8.staticflickr.com/7249/7811750326_614ea891ae.jpg" width="500" height="281" alt="rotext"></a>
 
@@ -10,7 +8,6 @@ Here is the graphics equivalent of "hello, world"
 
 	// first OpenVG program
 	// Anthony Starks (ajstarks@gmail.com)
-	// Adapted for paeryn's fork by paeryn
 	#include <stdio.h>
 	#include <stdlib.h>
 	#include <unistd.h>
@@ -23,23 +20,16 @@ Here is the graphics equivalent of "hello, world"
 		int width, height;
 		char s[3];
 	
-		// Request a window size of 600x360 with top-left at 20,20
-		initWindowSize(20, 20, 600, 360);
 		init(&width, &height);					// Graphics initialization
 	
-		// Remove Start as it sets up things we change anyway
 		Start(width, height);					// Start the picture
 		Background(0, 0, 0);					// Black background
 		Fill(44, 77, 232, 1);					// Big blue marble
-		Circle(width / 2, 0, width / 3);			// The "world" (made smaller)
-		Stroke(25, 125, 232, 1)				// Halo Colour
-		CircleOutline(width / 2, 0, (width / 3) + 5)	// Halo
-
+		Circle(width / 2, 0, width);			// The "world"
 		Fill(255, 255, 255, 1);					// White text
 		TextMid(width / 2, height / 2, "hello, world", SerifTypeface, width / 10);	// Greetings 
 		End();						   			// End the picture
-		WindowOpacity(128);	// Make the window half opacity
-					// Can now see what is behind it	
+	
 		fgets(s, 2, stdin);				   		// look at the pic, end with [RETURN]
 		finish();					            // Graphics cleanup
 		exit(0);
@@ -54,37 +44,11 @@ Here is the graphics equivalent of "hello, world"
 Coordinates are VGfloat values, with the origin at the lower left, with x increasing to the right, and y increasing up.
 OpenVG specifies colors as a VGfloat array containing red, green, blue, alpha values ranging from 0.0 to 1.0, but typically colors are specified as RGBA (0-255 for RGB, A from 0.0 to 1.0)
 
-	void initWindowSize(int x, int y, unsigned int w, unsigned int h)
-Define how big to make the window, and where to place the top-left corner (as
-measured from the top-left of the screen). If the width and height requested
-are larger than the screen size then the window size will be reduced to fit
-the screen. The x,y coordinate can be negative so that the window appears
-partially off screen, but will be clipped so that at least one pixel in each
-direction will be on the screen. The window won't be created until init() is
-called. If initWindowSize() isn't called first then the window will default to
-being at 0,0 with a width,height the same as the screen.
-
-	void init(&width, &height)
-Initialize the window and OpenVG. width and height will be filled with the
-window's size.
-
 	void Start(int width, int height)
 Begin the picture, clear the screen with a default white, set the stroke and fill to black.
 
-	void WindowClear()
-Clears the window to the colour set by Background() (or White if Start() was
-called and no subsequent Background() or BackgroundRGB() call has been made).
-Use this rather than Start() to avoid having to set the background colour every
-time if you want anything other than White and don't want the stroke, fill
-and stroke width settings reset.
-
 	void End()
 End the picture, rendering to the screen.
-
-	void WindowOpacity(unsigned int alpha)
-Sets the global alpha value of the window for display purposes (doesn't affect
-the alpha channel of the drawing surface).
-The alpha value can be between 0 (fully transparent) and 255 (fully opaque).
 
 	void SaveEnd(char *filename)
 End the picture, rendering to the screen, save the raster to the named file as 4-byte RGBA words, with a stride of
@@ -100,13 +64,6 @@ Set the fill color
 
 	void Background(unsigned int r, unsigned int g, unsigned int b)
 Fill the screen with the background color defined from RGB values.
-
-	void BackgroundRGB(unsigned int r, unsigned int g, unsigned int b, float a)
-Fill the screen with the background color defined from RGBA values.
-NOTE: in this (paeryn's) version the background alpha is ignored for display
-purposes - instead a global alpha is used for the whole window. This doesn't
-affect the usage of the alpha channel for blending purposes, only for display
-purposes.
 
 	void StrokeWidth(float width)
 Set the stroke width.
@@ -161,17 +118,6 @@ Draw a cubic bezier curve beginning at (sx, sy), using control points at (cx, cy
 
 	void Arc(VGfloat x, VGfloat y, VGfloat w, VGfloat h, VGfloat sa, VGfloat aext)
 Draw an elliptical arc centered at (x, y), with width and height at (w, h).  Start angle (degrees) is sa, angle extent is aext.
-
-
-Outlined versions of above shapes (omitting the need to set a transparent fill)
-
-	void RectOutline(VGfloat x, VGfloat y, VGfloat w, VGfloat h)
-	void RoundrectOutline(VGfloat x, VGfloat y, VGfloat w, VGfloat h, VGfloat rw, VGfloat rh)
-	void CircleOutline(VGfloat x, VGfloat y, VGfloat r)
-	void EllipseOutline(VGfloat x, VGfloat y, VGfloat w, VGfloat h)
-	void ArcOutline(VGfloat x, VGfloat y, VGfloat w, VGfloat h, VGfloat sa, VGfloat aext)
-	void QbezierOutline(VGfloat sx, VGfloat sy, VGfloat cx, VGfloat cy, VGfloat ex, VGfloat ey)
-	void CbezierOutline(VGfloat sx, VGfloat sy, VGfloat cx, VGfloat cy, VGfloat px, VGfloat py, VGfloat ex, VGfloat ey)
 
 ### Text and Images
 
@@ -294,8 +240,6 @@ The openvg shapes library can now be used in C code by including shapes.h and fo
 <a href="http://www.flickr.com/photos/ajstarks/7883988028/" title="The Raspberry Pi, drawn by the Raspberry Pi by ajstarks, on Flickr"><img src="http://farm9.staticflickr.com/8442/7883988028_21fd6533e0.jpg" width="500" height="281" alt="The Raspberry Pi, drawn by the Raspberry Pi"></a>
 
 ## Go wrapper
-
-NOTE: Due to paeryn's lack of Go knowledge this version hasn't currently updadted the Go wrapper so the added functionality is not there.
 
 A Go programming language wrapper for the library is found in openvg.go. Sample clients are in the directory go-client.  The API closely follows the C API; here is the "hello, world" program in Go:
 

--- a/client/hellovg.c
+++ b/client/hellovg.c
@@ -1,5 +1,4 @@
 // first OpenVG program
-// Anthony Starks (ajstarks@gmail.com)
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -11,7 +10,9 @@
 int main() {
 	int width, height;
 	char s[3];
-
+	char hello1[] = {'H','e','j',',',' ','v', 0xc3, 0xa4,'r' , 'l','d' ,'e','n',0};
+	char hello2[] = {'H','e','l','l',0xc3,0xb3,' ', 'V', 'i', 'l', 0xc3,0xa1,'g',0};
+	char hello3[] = {'A','h','o','j',' ','s','v',0xc4,0x95,'t','e',0};
 	init(&width, &height);				   // Graphics initialization
 
 	Start(width, height);				   // Start the picture
@@ -19,7 +20,10 @@ int main() {
 	Fill(44, 77, 232, 1);				   // Big blue marble
 	Circle(width / 2, 0, width);			   // The "world"
 	Fill(255, 255, 255, 1);				   // White text
-	TextMid(width / 2, height / 2, "hello, world", SerifTypeface, width / 10);	// Greetings 
+	TextMid(width / 2, (height * 0.7), "hello, world", SerifTypeface, width / 15);	// Greetings 
+	TextMid(width / 2, (height * 0.5), hello1 , SerifTypeface, width / 15);
+	TextMid(width / 2, (height * 0.3), hello2 , SerifTypeface, width / 15);
+	TextMid(width / 2, (height * 0.1), hello3 , SerifTypeface, width / 15);
 	End();						   // End the picture
 
 	fgets(s, 2, stdin);				   // look at the pic, end with [RETURN]

--- a/eglstate.h
+++ b/eglstate.h
@@ -1,7 +1,16 @@
 typedef struct {
+	// Screen dimentions
 	uint32_t screen_width;
 	uint32_t screen_height;
-	// OpenGL|ES objects
+	// Window dimentions
+	int32_t window_x;
+	int32_t window_y;
+	uint32_t window_width;
+	uint32_t window_height;
+	// dispman window 
+	DISPMANX_ELEMENT_HANDLE_T element;
+
+	// EGL data
 	EGLDisplay display;
 
 	EGLSurface surface;
@@ -9,3 +18,5 @@ typedef struct {
 } STATE_T;
 
 extern void oglinit(STATE_T *);
+extern void dispmanMoveWindow(STATE_T *, int, int);
+extern void dispmanChangeWindowOpacity(STATE_T *, unsigned int);

--- a/libshapes.c
+++ b/libshapes.c
@@ -18,7 +18,7 @@
 #include "eglstate.h"					   // data structures for graphics state
 #include "fontinfo.h"					   // font data structure
 static STATE_T _state, *state = &_state;	// global graphics state
-static const int MAXFONTPATH = 256;
+static const int MAXFONTPATH = 500;
 //
 // Terminal settings
 //
@@ -396,15 +396,38 @@ void ClipEnd() {
 	vgSeti(VG_SCISSORING, VG_FALSE);
 }
 
+unsigned char *next_utf8_char(unsigned char *utf8, int *codepoint) {
+	int seqlen;
+	int datalen = (int)strlen(utf8);
+	unsigned char *p = utf8;
+
+	if (datalen < 1 || *utf8 == 0) { // End of string
+		return NULL;
+	}
+	if (!(utf8[0] & 0x80)) {			 // 0xxxxxxx
+		*codepoint = (wchar_t) utf8[0];
+		seqlen = 1;
+	} else if ((utf8[0] & 0xE0) == 0xC0) {		   // 110xxxxx 
+		*codepoint = (int)(((utf8[0] & 0x1F) << 6) | (utf8[1] & 0x3F));
+		seqlen = 2;
+	} else if ((utf8[0] & 0xF0) == 0xE0) {		   // 1110xxxx
+		*codepoint = (int)(((utf8[0] & 0x0F) << 12) | ((utf8[1] & 0x3F) << 6) | (utf8[2] & 0x3F));
+		seqlen = 3;
+	} else {
+		return NULL;				   // No code points this high here
+	}
+	p += seqlen;
+	return p;
+}
+
 // Text renders a string of text at a specified location, size, using the specified font glyphs
 // derived from http://web.archive.org/web/20070808195131/http://developer.hybrid.fi/font2openvg/renderFont.cpp.txt
 void Text(VGfloat x, VGfloat y, char *s, Fontinfo f, int pointsize) {
 	VGfloat size = (VGfloat) pointsize, xx = x, mm[9];
-	int i;
-
 	vgGetMatrix(mm);
-	for (i = 0; i < (int)strlen(s); i++) {
-		unsigned int character = (unsigned int)s[i];
+	int character;
+	unsigned char *ss = s;
+	while ((ss = next_utf8_char(ss, &character)) != NULL) {
 		int glyph = f.CharacterMap[character];
 		if (glyph == -1) {
 			continue;			   //glyph is undefined
@@ -424,11 +447,11 @@ void Text(VGfloat x, VGfloat y, char *s, Fontinfo f, int pointsize) {
 
 // TextWidth returns the width of a text string at the specified font and size.
 VGfloat TextWidth(char *s, Fontinfo f, int pointsize) {
-	int i;
 	VGfloat tw = 0.0;
 	VGfloat size = (VGfloat) pointsize;
-	for (i = 0; i < (int)strlen(s); i++) {
-		unsigned int character = (unsigned int)s[i];
+	int character;
+	unsigned char *ss = s;
+	while ((ss = next_utf8_char(ss, &character)) != NULL) {
 		int glyph = f.CharacterMap[character];
 		if (glyph == -1) {
 			continue;			   //glyph is undefined

--- a/libshapes.c
+++ b/libshapes.c
@@ -10,7 +10,7 @@
 #include "VG/openvg.h"
 #include "VG/vgu.h"
 #include "EGL/egl.h"
-#include "GLES/gl.h"
+//#include "GLES/gl.h"
 #include "bcm_host.h"
 #include "DejaVuSans.inc"				   // font data
 #include "DejaVuSerif.inc"
@@ -18,7 +18,7 @@
 #include "eglstate.h"					   // data structures for graphics state
 #include "fontinfo.h"					   // font data structure
 static STATE_T _state, *state = &_state;	// global graphics state
-static const int MAXFONTPATH = 256;	// consistent with fontinfo.h
+static const int MAXFONTPATH = 500;
 static int init_x = 0;		// Initial window position and size
 static int init_y = 0;
 static unsigned int init_w = 0;

--- a/oglinit.c
+++ b/oglinit.c
@@ -1,12 +1,76 @@
 #include <EGL/egl.h>
-#include <GLES/gl.h>
 #include "eglstate.h"
 #include <bcm_host.h>
 #include <assert.h>
 
-// oglinit sets the display, OpenGL|ES context and screen information
-// state holds the OGLES model information
-extern void oglinit(STATE_T * state) {
+// setWindowParams sets the window's position, adjusting if need be to
+// prevent it from going fully off screen. Also sets the dispman rects
+// for displaying.
+static void setWindowParams(STATE_T * state, int x, int y,  VC_RECT_T *src_rect, VC_RECT_T *dst_rect)
+{
+	uint32_t dx, dy, w, h, sx, sy;
+
+	// Set source & destination rectangles so that the image is
+	// clipped if it goes off screen (else dispman won't show it properly)
+	if (x < (1 - (int)state->window_width)) { // Too far off left
+		x = 1 - (int)state->window_width;
+		dx = 0;
+		sx = state->window_width - 1;
+		w = 1;
+	} else if (x < 0) { // Part of left is off
+		dx = 0;
+		sx = -x;
+		w = state->window_width - sx;
+	} else if (x < (state->screen_width - state->window_width)) { // On
+		dx = x;
+		sx = 0;
+		w = state->window_width;
+	} else if (x < state->screen_width) { // Part of right is off
+		dx = x;
+		sx = 0;
+		w = state->screen_width - x;
+	} else { // Too far off right
+		x = state->screen_width - 1;
+		dx = state->screen_width - 1;
+		sx = 0;
+		w = 1;
+	}
+
+	if (y < (1 - (int)state->window_height)) { // Too far off top
+		y = 1 - (int)state->window_height;
+		dy = 0;
+		sy = state->window_height - 1;
+		h = 1;
+	} else if (y < 0) { // Part of top is off
+		dy = 0;
+		sy = -y;
+		h = state->window_height - sy;
+	} else if (y < (state->screen_height - state->window_height)) { // On
+		dy = y;
+		sy = 0;
+		h = state->window_height;
+	} else if (y < state->screen_height) { // Part of bottom is off
+		dy = y;
+		sy = 0;
+		h = state->screen_height - y;
+	} else { // Wholly off bottom
+		y = state->screen_height - 1;
+		dy = state->screen_height - 1;
+		sy = 0;
+		h = 1;
+	}
+
+	state->window_x = x;
+	state->window_y = y;
+
+	vc_dispmanx_rect_set(dst_rect, dx, dy, w, h);
+	vc_dispmanx_rect_set(src_rect, sx << 16, sy << 16, w << 16, h << 16);
+}
+
+
+// oglinit sets the display, OpenVGL context and screen information
+// state holds the display information
+void oglinit(STATE_T * state) {
 	int32_t success = 0;
 	EGLBoolean result;
 	EGLint num_config;
@@ -18,6 +82,10 @@ extern void oglinit(STATE_T * state) {
 	DISPMANX_UPDATE_HANDLE_T dispman_update;
 	VC_RECT_T dst_rect;
 	VC_RECT_T src_rect;
+	static VC_DISPMANX_ALPHA_T alpha = {
+		DISPMANX_FLAGS_ALPHA_FIXED_ALL_PIXELS,
+		255, 0
+	};
 
 	static const EGLint attribute_list[] = {
 		EGL_RED_SIZE, 8,
@@ -54,26 +122,26 @@ extern void oglinit(STATE_T * state) {
 					    &state->screen_height);
 	assert(success >= 0);
 
-	dst_rect.x = 0;
-	dst_rect.y = 0;
-	dst_rect.width = state->screen_width;
-	dst_rect.height = state->screen_height;
+	if ((state->window_width == 0) || (state->window_width > state->screen_width))
+		state->window_width = state->screen_width;
+	if ((state->window_height == 0) || (state->window_height > state->screen_height))
+		state->window_height = state->screen_height;
 
-	src_rect.x = 0;
-	src_rect.y = 0;
-	src_rect.width = state->screen_width << 16;
-	src_rect.height = state->screen_height << 16;
+	// adjust position so that at least one pixel is on screen and
+	// set up the dispman rects
+	setWindowParams(state, state->window_x, state->window_y, &src_rect, &dst_rect);
 
 	dispman_display = vc_dispmanx_display_open(0 /* LCD */ );
 	dispman_update = vc_dispmanx_update_start(0);
 
 	dispman_element = vc_dispmanx_element_add(dispman_update, dispman_display, 0 /*layer */ , &dst_rect, 0 /*src */ ,
-						  &src_rect, DISPMANX_PROTECTION_NONE, 0 /*alpha */ , 0 /*clamp */ ,
+						  &src_rect, DISPMANX_PROTECTION_NONE, &alpha, 0 /*clamp */ ,
 						  0 /*transform */ );
 
+	state->element = dispman_element;
 	nativewindow.element = dispman_element;
-	nativewindow.width = state->screen_width;
-	nativewindow.height = state->screen_height;
+	nativewindow.width = state->window_width;
+	nativewindow.height = state->window_height;
 	vc_dispmanx_update_submit_sync(dispman_update);
 
 	state->surface = eglCreateWindowSurface(state->display, config, &nativewindow, NULL);
@@ -86,13 +154,36 @@ extern void oglinit(STATE_T * state) {
 	// connect the context to the surface
 	result = eglMakeCurrent(state->display, state->surface, state->surface, state->context);
 	assert(EGL_FALSE != result);
+}
 
-	// set up screen ratio
-	glViewport(0, 0, (GLsizei) state->screen_width, (GLsizei) state->screen_height);
+// dispmanMoveWindow repositions the openVG window to given coords
+// -ve coords are allowed upto (1-width,1-height),
+// max (screen_width-1,screen_height-1). i.e. at least one pixel must be
+// on the screen.
+void dispmanMoveWindow(STATE_T * state, int x, int y)
+{
+	VC_RECT_T src_rect, dst_rect;
+	DISPMANX_UPDATE_HANDLE_T dispman_update;
 
-	glMatrixMode(GL_PROJECTION);
-	glLoadIdentity();
+	setWindowParams(state, x, y, &src_rect, &dst_rect);
+	dispman_update = vc_dispmanx_update_start(0);
+	vc_dispmanx_element_change_attributes(dispman_update, state->element,
+		0, 0, 0, &dst_rect, &src_rect, 0, DISPMANX_NO_ROTATE);
+	vc_dispmanx_update_submit_sync(dispman_update);
+}
 
-	float ratio = (float)state->screen_width / (float)state->screen_height;
-	glFrustumf(-ratio, ratio, -1.0f, 1.0f, 1.0f, 10.0f);
+// dispmanChangeWindowOpacity changes the window's opacity
+// 0 = transparent, 255 = opaque
+void dispmanChangeWindowOpacity(STATE_T * state, uint32_t alpha)
+{
+	DISPMANX_UPDATE_HANDLE_T dispman_update;
+
+	if (alpha > 255)
+		alpha = 235;
+
+	dispman_update = vc_dispmanx_update_start(0);
+	// The 1<<1 below means update the alpha value
+	vc_dispmanx_element_change_attributes(dispman_update, state->element,
+		1<<1, 0, alpha, 0, 0, 0, DISPMANX_NO_ROTATE);
+	vc_dispmanx_update_submit_sync(dispman_update);
 }

--- a/shapes.h
+++ b/shapes.h
@@ -48,6 +48,11 @@ extern "C" {
 	extern void saveterm();
 	extern void restoreterm();
 	extern void rawterm();
+
+	extern void initWindowSize(int x, int y, unsigned int w, unsigned int h);
+	extern void WindowClear();
+	extern void WindowOpacity(unsigned int alpha);
+	extern void WindowPosition(int x, int y);
 #if defined(__cplusplus)
 }
 #endif


### PR DESCRIPTION
Changed from forced fullscreen to allowing user to set size and position of OpenVG window. Size currently remains fixed, but position can be changed at any time. Also opacity of the window can be changed at any time.

Added outline versions of the shapes - better than requiring the fill to be set to a zero-alpha colour. This could also be done by changing the original functions to need the FILL / STROKE flags but I tried to preserve the original function prototypes.

Changed newpath() to allocate VG_CAPABILITIES_APPEND_TO paths since the other capabilities aren't used at the moment and gives the driver chance to optimise.

Adjusted the MAXFONTPATH, as it was it was segfaulting due to trying to clear 500 Glyphs rather than the 256 declared in fontinfo.h

I've not updated the Go part as I'm not familiar at the moment with Go and I didn't want to mess it up.